### PR TITLE
Enhance backtest results display with new cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -426,6 +426,7 @@ body {
 .widget-grid .card {
   display: flex;
   flex-direction: column;
+  height: 100%;
 }
 
 .widget-grid .card > *:last-child {


### PR DESCRIPTION
Add four new backtest result cards (Initial Capital, Composition, Rebalancing, Dates/Period), reorder the comparison widget to always appear after results, and update card CSS for full widget space to complete the backtest results view.

---
<a href="https://cursor.com/background-agent?bcId=bc-7664625a-7020-4c12-b8a4-7488a6ccda3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7664625a-7020-4c12-b8a4-7488a6ccda3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

